### PR TITLE
Run one-shot batch capture fixes

### DIFF
--- a/.github/run-one-shot-batch-fix.trigger
+++ b/.github/run-one-shot-batch-fix.trigger
@@ -1,0 +1,1 @@
+Trigger the validated one-shot batch state, glass dialog, and retained author display workflow.


### PR DESCRIPTION
Temporary trigger PR for the validated workflow that fixes batch stop state recovery, the borderless acrylic batch dialog, and retaining the current author display until the next capture starts.