### PR TITLE
Add editable remote API port settings

### DIFF
--- a/src/HelloCrab.Core/Services/Settings/RemoteApiPortState.cs
+++ b/src/HelloCrab.Core/Services/Settings/RemoteApiPortState.cs
@@ -1,0 +1,18 @@
+namespace HelloCrab.Core.Services.Settings;
+
+/// <summary>
+/// 保存当前进程实际使用的远程 API 端口。
+/// SettingsService 负责从 settings.json 初始化，并在每次保存设置时写回。
+/// </summary>
+public static class RemoteApiPortState
+{
+    private static int _current = 5088;
+
+    public static int Current => Volatile.Read(ref _current);
+
+    public static int Normalize(int value)
+        => Math.Clamp(value, 1024, 65535);
+
+    public static void Set(int value)
+        => Volatile.Write(ref _current, Normalize(value));
+}

--- a/src/HelloCrab.Core/Services/Settings/SettingsService.cs
+++ b/src/HelloCrab.Core/Services/Settings/SettingsService.cs
@@ -39,6 +39,7 @@ public sealed class SettingsService
             {
                 var defaults = new AppSettings();
                 EnsureRemoteToken(defaults);
+                RemoteApiPortState.Set(defaults.RemoteApiPort);
                 return defaults;
             }
 
@@ -73,7 +74,8 @@ public sealed class SettingsService
                 settings.DuplicateStopThreshold,
                 1,
                 10000);
-            settings.RemoteApiPort = Math.Clamp(settings.RemoteApiPort, 1024, 65535);
+            settings.RemoteApiPort = RemoteApiPortState.Normalize(settings.RemoteApiPort);
+            RemoteApiPortState.Set(settings.RemoteApiPort);
             EnsureRemoteToken(settings);
 
             return settings;
@@ -83,6 +85,7 @@ public sealed class SettingsService
             // 设置文件损坏时不阻止程序启动，后续保存会用当前有效设置覆盖它。
             var defaults = new AppSettings();
             EnsureRemoteToken(defaults);
+            RemoteApiPortState.Set(defaults.RemoteApiPort);
             return defaults;
         }
     }
@@ -99,6 +102,10 @@ public sealed class SettingsService
             var directory = Path.GetDirectoryName(SettingsPath);
             if (!string.IsNullOrWhiteSpace(directory))
                 Directory.CreateDirectory(directory);
+
+            // MainWindowViewModel 的其他设置可能在端口修改后继续触发延迟保存。
+            // 每次序列化前都使用当前进程端口，避免旧快照把新端口覆盖回去。
+            settings.RemoteApiPort = RemoteApiPortState.Current;
 
             var json = JsonSerializer.Serialize(settings, JsonOptions);
             var tempPath = SettingsPath + ".tmp";

--- a/src/HelloCrab.Core/ViewModels/MainWindowViewModel.RemotePort.cs
+++ b/src/HelloCrab.Core/ViewModels/MainWindowViewModel.RemotePort.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using CommunityToolkit.Mvvm.Input;
+using HelloCrab.Core.Services.Settings;
+
+namespace HelloCrab.Core.ViewModels;
+
+public sealed partial class MainWindowViewModel
+{
+    private string? _remoteApiPortDraft;
+    private IRelayCommand? _applyRemoteApiPortCommand;
+
+    /// <summary>桌面远程服务当前应实际监听的端口。</summary>
+    public int EffectiveRemoteApiPort => RemoteApiPortState.Current;
+
+    public string RemoteApiPortDraft
+    {
+        get => _remoteApiPortDraft ??=
+            EffectiveRemoteApiPort.ToString(CultureInfo.InvariantCulture);
+        set => SetProperty(ref _remoteApiPortDraft, value ?? string.Empty);
+    }
+
+    public IRelayCommand ApplyRemoteApiPortCommand
+        => _applyRemoteApiPortCommand ??= new RelayCommand(ApplyRemoteApiPort);
+
+    public event EventHandler<int>? RemoteApiPortChanged;
+
+    private void ApplyRemoteApiPort()
+    {
+        var text = RemoteApiPortDraft.Trim();
+        if (!int.TryParse(
+                text,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var port)
+            || port is < 1024 or > 65535)
+        {
+            var message = RemotePortText(
+                "远程端口无效：请输入 1024–65535 之间的整数。",
+                "Invalid remote port. Enter an integer from 1024 to 65535.",
+                "リモートポートが無効です。1024～65535 の整数を入力してください。");
+            SetRemoteApiStatus(message);
+            AddRemoteLog(message);
+            return;
+        }
+
+        RemoteApiPortDraft = port.ToString(CultureInfo.InvariantCulture);
+        if (port == EffectiveRemoteApiPort)
+        {
+            AddRemoteLog(RemotePortText(
+                $"远程端口没有变化：{port}",
+                $"The remote port is unchanged: {port}",
+                $"リモートポートは変更されていません：{port}"));
+            return;
+        }
+
+        RemoteApiPortState.Set(port);
+        OnPropertyChanged(nameof(EffectiveRemoteApiPort));
+        QueueSettingsSave();
+
+        SetRemoteApiStatus(RemoteApiEnabled
+            ? RemotePortText(
+                $"正在切换远程端口到 {port}…",
+                $"Switching the remote port to {port}…",
+                $"リモートポートを {port} に切り替えています…")
+            : RemotePortText(
+                $"已关闭 · 已保存端口 {port}",
+                $"Disabled · Port {port} saved",
+                $"無効 · ポート {port} を保存しました"));
+
+        AddRemoteLog(RemotePortText(
+            $"远程端口已保存：{port}",
+            $"Remote port saved: {port}",
+            $"リモートポートを保存しました：{port}"));
+        RemoteApiPortChanged?.Invoke(this, port);
+    }
+
+    private string RemotePortText(string zhCn, string enUs, string jaJp)
+    {
+        var code = _localization.CurrentLanguageCode;
+        if (code.StartsWith("en", StringComparison.OrdinalIgnoreCase))
+            return enUs;
+        if (code.StartsWith("ja", StringComparison.OrdinalIgnoreCase))
+            return jaJp;
+        return zhCn;
+    }
+}

--- a/src/HelloCrab.Core/Views/MainWindow.RemotePortEditor.cs
+++ b/src/HelloCrab.Core/Views/MainWindow.RemotePortEditor.cs
@@ -1,0 +1,65 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using HelloCrab.Core.ViewModels;
+
+namespace HelloCrab.Core.Views;
+
+public partial class MainWindow
+{
+    private static readonly IDisposable RemotePortEditorDataContextHandler =
+        StyledElement.DataContextProperty.Changed.AddClassHandler<MainWindow>((window, _) =>
+            Dispatcher.UIThread.Post(
+                window.EnsureRemotePortEditor,
+                DispatcherPriority.Loaded));
+
+    private bool _remotePortEditorInstalled;
+    private int _remotePortEditorInstallAttempts;
+
+    private void EnsureRemotePortEditor()
+    {
+        if (_remotePortEditorInstalled || DataContext is not MainWindowViewModel viewModel)
+            return;
+
+        var portText = this
+            .GetVisualDescendants()
+            .OfType<TextBlock>()
+            .FirstOrDefault(textBlock =>
+                Grid.GetRow(textBlock) == 1
+                && Grid.GetColumn(textBlock) == 1
+                && textBlock.Parent is Grid grid
+                && grid.RowDefinitions.Count == 3
+                && grid.ColumnDefinitions.Count == 2
+                && grid.Children
+                    .OfType<StackPanel>()
+                    .Any(panel =>
+                        Grid.GetRow(panel) == 2
+                        && Grid.GetColumn(panel) == 1));
+
+        if (portText?.Parent is not Grid remoteSettingsGrid)
+        {
+            if (++_remotePortEditorInstallAttempts <= 8)
+            {
+                Dispatcher.UIThread.Post(
+                    EnsureRemotePortEditor,
+                    DispatcherPriority.Background);
+            }
+            return;
+        }
+
+        remoteSettingsGrid.Children.Remove(portText);
+        var editor = new RemotePortEditor
+        {
+            DataContext = viewModel,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        Grid.SetRow(editor, 1);
+        Grid.SetColumn(editor, 1);
+        remoteSettingsGrid.Children.Add(editor);
+
+        _remotePortEditorInstalled = true;
+    }
+}

--- a/src/HelloCrab.Core/Views/RemotePortEditor.axaml
+++ b/src/HelloCrab.Core/Views/RemotePortEditor.axaml
@@ -1,0 +1,35 @@
+<UserControl
+    x:Class="HelloCrab.Core.Views.RemotePortEditor"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:vm="using:HelloCrab.Core.ViewModels"
+    x:DataType="vm:MainWindowViewModel">
+  <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+    <TextBox Text="{Binding RemoteApiPortDraft, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+             Watermark="1024–65535"
+             MaxLength="5"
+             FontFamily="Consolas,Menlo,Monospace"
+             MinHeight="38"
+             VerticalAlignment="Center"
+             VerticalContentAlignment="Center" />
+    <Button Grid.Column="1"
+            Width="36"
+            Height="34"
+            MinWidth="36"
+            MinHeight="34"
+            Padding="0"
+            Background="#FD6F71"
+            Foreground="White"
+            VerticalAlignment="Center"
+            HorizontalContentAlignment="Center"
+            VerticalContentAlignment="Center"
+            Command="{Binding ApplyRemoteApiPortCommand}">
+      <TextBlock Text="&#xE74E;"
+                 FontFamily="Segoe Fluent Icons,Segoe MDL2 Assets"
+                 FontSize="16"
+                 Foreground="White"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center" />
+    </Button>
+  </Grid>
+</UserControl>

--- a/src/HelloCrab.Core/Views/RemotePortEditor.axaml.cs
+++ b/src/HelloCrab.Core/Views/RemotePortEditor.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 
 namespace HelloCrab.Core.Views;
 
@@ -7,6 +6,6 @@ public partial class RemotePortEditor : UserControl
 {
     public RemotePortEditor()
     {
-        AvaloniaXamlLoader.Load(this);
+        InitializeComponent();
     }
 }

--- a/src/HelloCrab.Core/Views/RemotePortEditor.axaml.cs
+++ b/src/HelloCrab.Core/Views/RemotePortEditor.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace HelloCrab.Core.Views;
+
+public partial class RemotePortEditor : UserControl
+{
+    public RemotePortEditor()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/HelloCrab.Desktop/App.axaml.cs
+++ b/src/HelloCrab.Desktop/App.axaml.cs
@@ -31,6 +31,7 @@ namespace HelloCrab.Desktop;
 
 public partial class App : Application
 {
+    private readonly SemaphoreSlim _remoteApiOperationGate = new(1, 1);
     private RemoteApiHostService? _remoteApiHost;
     private MainWindowViewModel? _viewModel;
     private GyanFfmpegInstallerService? _ffmpegInstaller;
@@ -80,6 +81,7 @@ public partial class App : Application
             _viewModel = viewModel;
             _remoteApiHost = new RemoteApiHostService(viewModel);
             viewModel.RemoteApiEnabledChanged += ViewModel_RemoteApiEnabledChanged;
+            viewModel.RemoteApiPortChanged += ViewModel_RemoteApiPortChanged;
 
             desktop.MainWindow = new MainWindow
             {
@@ -96,13 +98,20 @@ public partial class App : Application
     private void ViewModel_RemoteApiEnabledChanged(object? sender, bool enabled)
         => _ = ApplyRemoteServerStateAsync(enabled);
 
+    private void ViewModel_RemoteApiPortChanged(object? sender, int port)
+    {
+        if (_viewModel?.RemoteApiEnabled == true)
+            _ = RestartRemoteServerAsync();
+    }
+
     private async Task ApplyRemoteServerStateAsync(bool enabled)
     {
-        if (_remoteApiHost is null)
-            return;
-
+        await _remoteApiOperationGate.WaitAsync();
         try
         {
+            if (_remoteApiHost is null)
+                return;
+
             await _remoteApiHost.SetEnabledAsync(enabled);
         }
         catch (Exception ex)
@@ -110,15 +119,58 @@ public partial class App : Application
             _viewModel?.AddRemoteLog($"切换远程控制服务器失败：{ex.Message}");
             _viewModel?.SetRemoteApiStatus($"启动失败：{ex.Message}");
         }
+        finally
+        {
+            _remoteApiOperationGate.Release();
+        }
+    }
+
+    private async Task RestartRemoteServerAsync()
+    {
+        await _remoteApiOperationGate.WaitAsync();
+        try
+        {
+            var oldHost = _remoteApiHost;
+            _remoteApiHost = null;
+            if (oldHost is not null)
+                await oldHost.DisposeAsync();
+
+            if (_viewModel is null || !_viewModel.RemoteApiEnabled)
+                return;
+
+            _remoteApiHost = new RemoteApiHostService(_viewModel);
+            await _remoteApiHost.SetEnabledAsync(true);
+        }
+        catch (Exception ex)
+        {
+            _viewModel?.AddRemoteLog($"切换远程端口失败：{ex.Message}");
+            _viewModel?.SetRemoteApiStatus($"启动失败：{ex.Message}");
+        }
+        finally
+        {
+            _remoteApiOperationGate.Release();
+        }
     }
 
     private async void Desktop_Exit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
     {
         if (_viewModel is not null)
+        {
             _viewModel.RemoteApiEnabledChanged -= ViewModel_RemoteApiEnabledChanged;
+            _viewModel.RemoteApiPortChanged -= ViewModel_RemoteApiPortChanged;
+        }
 
-        if (_remoteApiHost is not null)
-            await _remoteApiHost.DisposeAsync();
+        await _remoteApiOperationGate.WaitAsync();
+        try
+        {
+            if (_remoteApiHost is not null)
+                await _remoteApiHost.DisposeAsync();
+        }
+        finally
+        {
+            _remoteApiOperationGate.Release();
+            _remoteApiOperationGate.Dispose();
+        }
 
         _ffmpegInstaller?.Dispose();
         _ffmpegInstaller = null;

--- a/src/HelloCrab.Desktop/Remote/RemoteApiHostService.cs
+++ b/src/HelloCrab.Desktop/Remote/RemoteApiHostService.cs
@@ -53,7 +53,7 @@ public sealed class RemoteApiHostService : IAsyncDisposable
     {
         if (_application is not null)
         {
-            _viewModel.SetRemoteApiStatus($"运行中 · 端口 {_viewModel.RemoteApiPort}");
+            _viewModel.SetRemoteApiStatus($"运行中 · 端口 {_viewModel.EffectiveRemoteApiPort}");
             return;
         }
 
@@ -63,7 +63,7 @@ public sealed class RemoteApiHostService : IAsyncDisposable
             _viewModel.SetRemoteApiStatus("正在启动远程服务器…");
 
             var builder = WebApplication.CreateSlimBuilder();
-            builder.WebHost.UseUrls($"http://0.0.0.0:{_viewModel.RemoteApiPort}");
+            builder.WebHost.UseUrls($"http://0.0.0.0:{_viewModel.EffectiveRemoteApiPort}");
             builder.Services.AddCors(options =>
             {
                 options.AddDefaultPolicy(policy => policy
@@ -159,10 +159,10 @@ public sealed class RemoteApiHostService : IAsyncDisposable
             _application = app;
 
             var addresses = GetLanAddresses()
-                .Select(address => $"http://{address}:{_viewModel.RemoteApiPort}")
+                .Select(address => $"http://{address}:{_viewModel.EffectiveRemoteApiPort}")
                 .ToArray();
             var addressText = addresses.Length == 0
-                ? $"http://127.0.0.1:{_viewModel.RemoteApiPort}"
+                ? $"http://127.0.0.1:{_viewModel.EffectiveRemoteApiPort}"
                 : string.Join("、", addresses);
 
             _viewModel.SetRemoteApiStatus($"运行中 · {addressText}");
@@ -174,8 +174,18 @@ public sealed class RemoteApiHostService : IAsyncDisposable
             if (app is not null)
                 await app.DisposeAsync();
 
-            _viewModel.SetRemoteApiStatus($"启动失败：{ex.Message}");
-            _viewModel.AddRemoteLog($"远程控制服务启动失败：{ex.Message}");
+            if (IsAddressAlreadyInUse(ex))
+            {
+                var message =
+                    $"启动失败：端口 {_viewModel.EffectiveRemoteApiPort} 已被占用，请修改远程端口后保存。";
+                _viewModel.SetRemoteApiStatus(message);
+                _viewModel.AddRemoteLog($"远程控制服务{message}");
+            }
+            else
+            {
+                _viewModel.SetRemoteApiStatus($"启动失败：{ex.Message}");
+                _viewModel.AddRemoteLog($"远程控制服务启动失败：{ex.Message}");
+            }
         }
     }
 
@@ -327,6 +337,23 @@ public sealed class RemoteApiHostService : IAsyncDisposable
         var rightBytes = System.Text.Encoding.UTF8.GetBytes(right);
         return leftBytes.Length == rightBytes.Length
                && System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(leftBytes, rightBytes);
+    }
+
+    private static bool IsAddressAlreadyInUse(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is SocketException { SocketErrorCode: SocketError.AddressAlreadyInUse })
+                return true;
+
+            if (current.Message.Contains("address already in use", StringComparison.OrdinalIgnoreCase)
+                || current.Message.Contains("地址已在使用", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static IEnumerable<string> GetLanAddresses()


### PR DESCRIPTION
## Changes

- replace the read-only remote API port display with an editable port control
- validate ports in the range 1024–65535
- persist the selected port to the existing `settings.json`
- automatically stop and restart the desktop remote API service after a port change
- keep a disabled server stopped while saving the new port for the next start
- report a clear message when the selected port is already in use
- serialize remote API lifecycle changes to avoid restart/toggle races

## Scope

No workflow file is added or modified.