### PR TITLE
Add skip-next-author control for manual batch downloads

### DIFF
--- a/src/HelloCrab.Core/ViewModels/MainWindowViewModel.BatchCapture.cs
+++ b/src/HelloCrab.Core/ViewModels/MainWindowViewModel.BatchCapture.cs
@@ -8,6 +8,7 @@ public sealed partial class MainWindowViewModel
 {
     private CancellationTokenSource? _manualBatchCts;
     private bool _isManualBatchRunning;
+    private bool _isManualBatchSkipRequested;
     private string? _retainedAuthorName;
     private string? _retainedAuthorAvatarUrl;
     private IImage? _retainedAuthorAvatarImage;
@@ -19,11 +20,20 @@ public sealed partial class MainWindowViewModel
         {
             if (SetProperty(ref _isManualBatchRunning, value))
             {
+                if (!value)
+                    IsManualBatchSkipRequested = false;
+
                 OnPropertyChanged(nameof(CanStopCurrentTask));
                 OnPropertyChanged(nameof(CanStartManualBatchCapture));
                 RefreshCommands();
             }
         }
+    }
+
+    public bool IsManualBatchSkipRequested
+    {
+        get => _isManualBatchSkipRequested;
+        private set => SetProperty(ref _isManualBatchSkipRequested, value);
     }
 
     public bool CanStartManualBatchCapture
@@ -57,6 +67,7 @@ public sealed partial class MainWindowViewModel
         using var stopRegistration = cts.Token.Register(_coordinator.Stop);
 
         IsManualBatchRunning = true;
+        IsManualBatchSkipRequested = false;
         IsBusy = true;
         ClearCurrentAuthorDisplayForNextCapture();
         var completedCount = 0;
@@ -117,7 +128,25 @@ public sealed partial class MainWindowViewModel
                         break;
                     }
 
+                    IsManualBatchSkipRequested = false;
                     await StartCaptureAsync();
+
+                    // “停止全部”优先级高于“跳过当前作者”。若两者同时发生，必须结束批量任务。
+                    cts.Token.ThrowIfCancellationRequested();
+
+                    if (IsManualBatchSkipRequested)
+                    {
+                        IsManualBatchSkipRequested = false;
+                        failedCount++;
+                        AddLog(BatchLocalizedText(
+                            "Batch.Log.ItemSkipped",
+                            "批量第 {0} 项已跳过，立即继续下一位作者。",
+                            "Batch item {0} was skipped. Moving to the next author immediately.",
+                            "一括処理の第 {0} 件をスキップし、すぐに次の作者へ進みます。",
+                            index + 1));
+                        continue;
+                    }
+
                     if (string.Equals(
                             _lastCoordinatorCompletionMessage,
                             "采集已停止",
@@ -142,6 +171,11 @@ public sealed partial class MainWindowViewModel
                         index + 1,
                         ex.Message));
                 }
+                finally
+                {
+                    IsManualBatchSkipRequested = false;
+                    AddManualBatchLogSeparator();
+                }
             }
 
             if (!cts.IsCancellationRequested)
@@ -165,6 +199,7 @@ public sealed partial class MainWindowViewModel
         finally
         {
             _manualBatchCts = null;
+            IsManualBatchSkipRequested = false;
 
             // 先释放通用忙碌状态，再结束批量状态，确保最后一次属性通知
             // 读取到的是最终可用状态，而不是 IsBusy=true 的中间状态。
@@ -202,6 +237,25 @@ public sealed partial class MainWindowViewModel
         });
     }
 
+    public bool SkipCurrentManualBatchAuthor()
+    {
+        if (!IsManualBatchRunning
+            || !IsCapturing
+            || IsManualBatchSkipRequested)
+        {
+            return false;
+        }
+
+        IsManualBatchSkipRequested = true;
+        AddLog(BatchLocalizedText(
+            "Batch.Log.SkipRequested",
+            "已请求跳过当前作者；正在停止当前采集，完成清理后立即处理下一位作者。",
+            "Skipping the current author. The next author will start as soon as cleanup finishes.",
+            "現在の作者をスキップします。終了処理後、すぐに次の作者を開始します。"));
+        _coordinator.Stop();
+        return true;
+    }
+
     public void CancelManualBatchCapture()
     {
         if (!IsManualBatchRunning
@@ -216,6 +270,12 @@ public sealed partial class MainWindowViewModel
         AddLog(BatchText(
             "Batch.Log.CancelRequested",
             "已请求停止批量采集；当前作者停止后不会继续处理后续地址。"));
+    }
+
+    private void AddManualBatchLogSeparator()
+    {
+        const string line = "────────────────────────────────────────────────────────────";
+        AddLog(string.Join(Environment.NewLine, Enumerable.Repeat(line, 10)));
     }
 
     internal void ClearCurrentAuthorDisplayForNextCapture()
@@ -261,6 +321,35 @@ public sealed partial class MainWindowViewModel
     private string BatchText(string key, string fallback, params object?[] arguments)
     {
         var template = _localization.Get(key, fallback);
+        try
+        {
+            return arguments.Length == 0
+                ? template
+                : string.Format(template, arguments);
+        }
+        catch (FormatException)
+        {
+            return arguments.Length == 0
+                ? fallback
+                : string.Format(fallback, arguments);
+        }
+    }
+
+    private string BatchLocalizedText(
+        string key,
+        string chineseFallback,
+        string englishFallback,
+        string japaneseFallback,
+        params object?[] arguments)
+    {
+        var languageCode = _localization.CurrentLanguageCode;
+        var fallback = languageCode.StartsWith("ja", StringComparison.OrdinalIgnoreCase)
+            ? japaneseFallback
+            : languageCode.StartsWith("en", StringComparison.OrdinalIgnoreCase)
+                ? englishFallback
+                : chineseFallback;
+        var template = _localization.Get(key, fallback);
+
         try
         {
             return arguments.Length == 0

--- a/src/HelloCrab.Core/Views/MainWindow.BatchSkip.cs
+++ b/src/HelloCrab.Core/Views/MainWindow.BatchSkip.cs
@@ -13,7 +13,6 @@ namespace HelloCrab.Core.Views;
 public partial class MainWindow
 {
     private Button? _batchSkipButton;
-    private Grid? _batchCaptureActionRow;
     private int _batchSkipEnsureAttempts;
 
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -53,8 +52,14 @@ public partial class MainWindow
             ColumnSpacing = 8,
             HorizontalAlignment = HorizontalAlignment.Stretch
         };
-        row.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
-        row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        row.ColumnDefinitions.Add(new ColumnDefinition
+        {
+            Width = new GridLength(1, GridUnitType.Star)
+        });
+        row.ColumnDefinitions.Add(new ColumnDefinition
+        {
+            Width = GridLength.Auto
+        });
 
         parent.Children.RemoveAt(buttonIndex);
         Grid.SetColumn(_batchCaptureButton, 0);
@@ -74,7 +79,6 @@ public partial class MainWindow
         row.Children.Add(skipButton);
 
         parent.Children.Insert(buttonIndex, row);
-        _batchCaptureActionRow = row;
         _batchSkipButton = skipButton;
 
         _batchCaptureViewModel.PropertyChanged += BatchSkipViewModel_PropertyChanged;

--- a/src/HelloCrab.Core/Views/MainWindow.BatchSkip.cs
+++ b/src/HelloCrab.Core/Views/MainWindow.BatchSkip.cs
@@ -1,0 +1,151 @@
+using System.ComponentModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using HelloCrab.Core.Services.Localization;
+using HelloCrab.Core.ViewModels;
+
+namespace HelloCrab.Core.Views;
+
+public partial class MainWindow
+{
+    private Button? _batchSkipButton;
+    private Grid? _batchCaptureActionRow;
+    private int _batchSkipEnsureAttempts;
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        Opened -= BatchSkipWindow_Opened;
+        Opened += BatchSkipWindow_Opened;
+    }
+
+    private void BatchSkipWindow_Opened(object? sender, EventArgs e)
+    {
+        // MainWindow.BatchCapture 会在 OnOpened 返回后以 Loaded 优先级创建批量按钮。
+        // 此处使用更低的 Background 优先级，确保原按钮先完成插入。
+        Dispatcher.UIThread.Post(EnsureBatchSkipButton, DispatcherPriority.Background);
+    }
+
+    private void EnsureBatchSkipButton()
+    {
+        if (_batchSkipButton is not null)
+            return;
+
+        if (_batchCaptureButton is null
+            || _batchCaptureViewModel is null
+            || _batchCaptureButton.Parent is not Panel parent)
+        {
+            if (++_batchSkipEnsureAttempts <= 20)
+                Dispatcher.UIThread.Post(EnsureBatchSkipButton, DispatcherPriority.Background);
+            return;
+        }
+
+        var buttonIndex = parent.Children.IndexOf(_batchCaptureButton);
+        if (buttonIndex < 0)
+            return;
+
+        var row = new Grid
+        {
+            ColumnSpacing = 8,
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+        row.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+        row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+
+        parent.Children.RemoveAt(buttonIndex);
+        Grid.SetColumn(_batchCaptureButton, 0);
+        row.Children.Add(_batchCaptureButton);
+
+        var skipButton = new Button
+        {
+            Classes = { "coral", "sectionAction" },
+            MinWidth = 156,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            IsVisible = false,
+            IsEnabled = false
+        };
+        skipButton.Click += BatchSkipButton_Click;
+        Grid.SetColumn(skipButton, 1);
+        row.Children.Add(skipButton);
+
+        parent.Children.Insert(buttonIndex, row);
+        _batchCaptureActionRow = row;
+        _batchSkipButton = skipButton;
+
+        _batchCaptureViewModel.PropertyChanged += BatchSkipViewModel_PropertyChanged;
+        Closed += BatchSkipWindow_Closed;
+        if (LocalizationService.Current is { } localization)
+            localization.LanguageChanged += OnBatchSkipLanguageChanged;
+
+        RefreshBatchSkipLocalizedText();
+        UpdateBatchSkipButtonState(_batchCaptureViewModel);
+    }
+
+    private void BatchSkipButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_batchCaptureViewModel?.SkipCurrentManualBatchAuthor() == true)
+            UpdateBatchSkipButtonState(_batchCaptureViewModel);
+    }
+
+    private void BatchSkipViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is not MainWindowViewModel viewModel
+            || e.PropertyName is not (
+                nameof(MainWindowViewModel.IsManualBatchRunning)
+                or nameof(MainWindowViewModel.IsCapturing)
+                or nameof(MainWindowViewModel.IsManualBatchSkipRequested)))
+        {
+            return;
+        }
+
+        UpdateBatchSkipButtonState(viewModel);
+    }
+
+    private void UpdateBatchSkipButtonState(MainWindowViewModel viewModel)
+    {
+        if (_batchSkipButton is null)
+            return;
+
+        _batchSkipButton.IsVisible = viewModel.IsManualBatchRunning;
+        _batchSkipButton.IsEnabled = viewModel.IsManualBatchRunning
+                                     && viewModel.IsCapturing
+                                     && !viewModel.IsManualBatchSkipRequested;
+    }
+
+    private void OnBatchSkipLanguageChanged(object? sender, EventArgs e)
+        => Dispatcher.UIThread.Post(RefreshBatchSkipLocalizedText);
+
+    private void RefreshBatchSkipLocalizedText()
+    {
+        if (_batchSkipButton is null)
+            return;
+
+        var localization = LocalizationService.Current;
+        var languageCode = localization?.CurrentLanguageCode ?? "zh-CN";
+        var fallback = languageCode.StartsWith("ja", StringComparison.OrdinalIgnoreCase)
+            ? "次の作者へ"
+            : languageCode.StartsWith("en", StringComparison.OrdinalIgnoreCase)
+                ? "Next author"
+                : "跳到下一个作者";
+
+        _batchSkipButton.Content = localization?.Get("Batch.SkipButton", fallback) ?? fallback;
+    }
+
+    private void BatchSkipWindow_Closed(object? sender, EventArgs e)
+    {
+        Opened -= BatchSkipWindow_Opened;
+        Closed -= BatchSkipWindow_Closed;
+
+        if (_batchSkipButton is not null)
+            _batchSkipButton.Click -= BatchSkipButton_Click;
+        if (_batchCaptureViewModel is not null)
+            _batchCaptureViewModel.PropertyChanged -= BatchSkipViewModel_PropertyChanged;
+        if (LocalizationService.Current is { } localization)
+            localization.LanguageChanged -= OnBatchSkipLanguageChanged;
+    }
+}


### PR DESCRIPTION
## Changes

- place the existing manual batch button and a new `Next author` button in one action row
- show the new button only while a manual batch is running
- enable it only while the current author is actively being captured
- distinguish skipping the current author from canceling the entire batch
- stop only the current `CrawlCoordinator` session when skip is requested
- continue immediately with the next valid author address after cleanup
- count manually skipped authors in the existing failed-or-skipped total
- add a 10-line separator block after each valid author task for easier log reading
- provide Chinese, English, and Japanese fallback text based on the active language

## Scope

Only the manual batch ViewModel and a new MainWindow partial file are changed. No workflow file is added or modified.