### PR TITLE
Update download history labels

### DIFF
--- a/src/HelloCrab.Core/Models/DownloadHistoryItem.cs
+++ b/src/HelloCrab.Core/Models/DownloadHistoryItem.cs
@@ -97,8 +97,7 @@ public sealed class DownloadHistoryItem : ObservableObject
     [JsonIgnore]
     public string UpdatedAtText => UpdatedAt == default
         ? LocalizationService.Current?.Get("History.NotDownloaded", "尚未下载") ?? "尚未下载"
-        : (LocalizationService.Current?.Format("History.LastDownloaded", UpdatedAt.LocalDateTime.ToString("yyyy-MM-dd HH:mm"))
-           ?? $"最后下载：{UpdatedAt.LocalDateTime:yyyy-MM-dd HH:mm}");
+        : FormatUpdatedAt(UpdatedAt.LocalDateTime);
 
     [JsonIgnore]
     public string ItemsSizeText => FormatBytes(ItemsSize);
@@ -113,6 +112,28 @@ public sealed class DownloadHistoryItem : ObservableObject
         OnPropertyChanged(nameof(UidText));
         OnPropertyChanged(nameof(UpdatedAtText));
         OnPropertyChanged(nameof(ItemsSummary));
+    }
+
+    private static string FormatUpdatedAt(DateTime updatedAt)
+    {
+        var localization = LocalizationService.Current;
+        var languageCode = localization?.CurrentLanguageCode ?? "zh-CN";
+        var fallback = languageCode.StartsWith("ja", StringComparison.OrdinalIgnoreCase)
+            ? "更新日時：{0}"
+            : languageCode.StartsWith("zh", StringComparison.OrdinalIgnoreCase)
+                ? "更新时间：{0}"
+                : "Updated: {0}";
+        var template = localization?.Get("History.UpdatedAt", fallback) ?? fallback;
+        var value = updatedAt.ToString("yyyy-MM-dd HH:mm");
+
+        try
+        {
+            return string.Format(template, value);
+        }
+        catch (FormatException)
+        {
+            return string.Format(fallback, value);
+        }
     }
 
     private static string FormatBytes(long bytes)

--- a/src/HelloCrab.Desktop/App.axaml
+++ b/src/HelloCrab.Desktop/App.axaml
@@ -62,5 +62,16 @@
     <Style Selector="TextBox[AcceptsReturn=true]:disabled /template/ Border#PART_BorderElement">
       <Setter Property="Background" Value="Transparent" />
     </Style>
+
+    <!-- 下载历史标题下方的旧操作提示不再显示；覆盖内置中、英、日语言。 -->
+    <Style Selector="TextBlock.caption[Text='最近下载优先 · 右击操作 · 拖动调整顺序']">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="TextBlock.caption[Text='Newest first · Right-click actions · Drag to reorder']">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="TextBlock.caption[Text='新しい順・右クリック操作・ドラッグで並べ替え']">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
   </Application.Styles>
 </Application>


### PR DESCRIPTION
## Changes

- hide the obsolete history hint text in built-in Chinese, English, and Japanese UIs
- rename the visible history timestamp label from last download to updated time
- display `更新时间`, `Updated`, or `更新日時` according to the active language
- keep support for a future/custom `History.UpdatedAt` language-pack key

## Scope

Only `DownloadHistoryItem.cs` and `App.axaml` are modified. No workflow file is added or changed.