### PR TITLE
Fix history hint removal and batch button width switching

### DIFF
--- a/src/HelloCrab.Core/Services/Localization/LocalizationService.cs
+++ b/src/HelloCrab.Core/Services/Localization/LocalizationService.cs
@@ -103,6 +103,10 @@ public sealed class LocalizationService : ObservableObject
         foreach (var pair in selected.Strings)
             strings[pair.Key] = pair.Value;
 
+        // 该提示已从界面设计中废弃。即使 exe 旁仍保留旧版语言 JSON，
+        // 或用户切换到自定义语言包，也不允许旧文案再次显示。
+        strings["History.Hint"] = string.Empty;
+
         if (Application.Current is { } app)
         {
             foreach (var oldKey in _appliedResourceKeys)
@@ -123,6 +127,9 @@ public sealed class LocalizationService : ObservableObject
 
     public string Get(string key, string? fallback = null)
     {
+        if (key.Equals("History.Hint", StringComparison.Ordinal))
+            return string.Empty;
+
         if (_packs.TryGetValue(CurrentLanguageCode, out var selected)
             && selected.Strings.TryGetValue(key, out var value))
         {

--- a/src/HelloCrab.Core/Views/MainWindow.BatchSkip.cs
+++ b/src/HelloCrab.Core/Views/MainWindow.BatchSkip.cs
@@ -47,7 +47,6 @@ public partial class MainWindow
         if (buttonIndex < 0)
             return;
 
-        // 与主界面的“开始采集 / 停止采集”按钮一致：两列等宽。
         var row = new Grid
         {
             ColumnSpacing = 8,
@@ -64,6 +63,8 @@ public partial class MainWindow
 
         parent.Children.RemoveAt(buttonIndex);
         Grid.SetColumn(_batchCaptureButton, 0);
+        // 默认没有批量任务时横跨左右两列，占满整行。
+        Grid.SetColumnSpan(_batchCaptureButton, 2);
         row.Children.Add(_batchCaptureButton);
 
         // 只使用 sectionAction，与“停止采集”保持相同背景和按钮样式。
@@ -113,11 +114,15 @@ public partial class MainWindow
 
     private void UpdateBatchSkipButtonState(MainWindowViewModel viewModel)
     {
-        if (_batchSkipButton is null)
+        if (_batchSkipButton is null || _batchCaptureButton is null)
             return;
 
-        _batchSkipButton.IsVisible = viewModel.IsManualBatchRunning;
-        _batchSkipButton.IsEnabled = viewModel.IsManualBatchRunning
+        var isBatchRunning = viewModel.IsManualBatchRunning;
+
+        // 未运行时主按钮占满两列；批量运行后缩为左半宽，右侧显示跳过按钮。
+        Grid.SetColumnSpan(_batchCaptureButton, isBatchRunning ? 1 : 2);
+        _batchSkipButton.IsVisible = isBatchRunning;
+        _batchSkipButton.IsEnabled = isBatchRunning
                                      && viewModel.IsCapturing
                                      && !viewModel.IsManualBatchSkipRequested;
     }

--- a/src/HelloCrab.Desktop/App.axaml
+++ b/src/HelloCrab.Desktop/App.axaml
@@ -62,16 +62,5 @@
     <Style Selector="TextBox[AcceptsReturn=true]:disabled /template/ Border#PART_BorderElement">
       <Setter Property="Background" Value="Transparent" />
     </Style>
-
-    <!-- 下载历史标题下方的旧操作提示不再显示；覆盖内置中、英、日语言。 -->
-    <Style Selector="TextBlock.caption[Text='最近下载优先 · 右击操作 · 拖动调整顺序']">
-      <Setter Property="IsVisible" Value="False" />
-    </Style>
-    <Style Selector="TextBlock.caption[Text='Newest first · Right-click actions · Drag to reorder']">
-      <Setter Property="IsVisible" Value="False" />
-    </Style>
-    <Style Selector="TextBlock.caption[Text='新しい順・右クリック操作・ドラッグで並べ替え']">
-      <Setter Property="IsVisible" Value="False" />
-    </Style>
   </Application.Styles>
 </Application>


### PR DESCRIPTION
## Changes

- suppress the obsolete `History.Hint` resource during every language apply, including stale language JSON files beside the executable and custom language packs
- remove the ineffective text-value selectors from `App.axaml`
- keep the manual batch button spanning both equal columns while no manual batch is running
- shrink the batch button to the left column only when the batch starts, then show the equal-width `Next author` button on the right
- restore the batch button to full width automatically when the batch ends

## Scope

Three normal source files are modified. No workflow file is added or changed.