### PR TITLE
Remove history hint directly from XAML

### DIFF
--- a/src/HelloCrab.Core/Services/Localization/LocalizationService.cs
+++ b/src/HelloCrab.Core/Services/Localization/LocalizationService.cs
@@ -103,10 +103,6 @@ public sealed class LocalizationService : ObservableObject
         foreach (var pair in selected.Strings)
             strings[pair.Key] = pair.Value;
 
-        // 该提示已从界面设计中废弃。即使 exe 旁仍保留旧版语言 JSON，
-        // 或用户切换到自定义语言包，也不允许旧文案再次显示。
-        strings["History.Hint"] = string.Empty;
-
         if (Application.Current is { } app)
         {
             foreach (var oldKey in _appliedResourceKeys)
@@ -127,9 +123,6 @@ public sealed class LocalizationService : ObservableObject
 
     public string Get(string key, string? fallback = null)
     {
-        if (key.Equals("History.Hint", StringComparison.Ordinal))
-            return string.Empty;
-
         if (_packs.TryGetValue(CurrentLanguageCode, out var selected)
             && selected.Strings.TryGetValue(key, out var value))
         {

--- a/src/HelloCrab.Core/Views/MainWindow.axaml
+++ b/src/HelloCrab.Core/Views/MainWindow.axaml
@@ -764,7 +764,6 @@
         <Grid RowDefinitions="Auto,Auto,Auto,*">
           <StackPanel>
             <TextBlock Text="{DynamicResource Lang.History.Title}" FontSize="19" FontWeight="SemiBold" />
-            <TextBlock Classes="caption" Text="{DynamicResource Lang.History.Hint}" Margin="0,3,0,0" />
           </StackPanel>
 
           <Border Grid.Row="1"


### PR DESCRIPTION
## Changes

- remove the obsolete history hint `TextBlock` directly from `MainWindow.axaml`
- remove the unnecessary `History.Hint` special cases from `LocalizationService`

The language-pack keys may remain unused without affecting the UI.

No workflow file is added or modified.