### PR TITLE
Add longer file name toggle

### DIFF
--- a/src/HelloCrab.Core/Services/Settings/AppSettings.cs
+++ b/src/HelloCrab.Core/Services/Settings/AppSettings.cs
@@ -2,7 +2,7 @@
 
 public sealed class AppSettings
 {
-    public int Version { get; set; } = 12;
+    public int Version { get; set; } = 13;
 
     /// <summary>
     /// Light 或 Dark。
@@ -17,6 +17,9 @@ public sealed class AppSettings
     public bool IncludeWorkId { get; set; } = false;
     public bool DownloadCover { get; set; }
     public bool DownloadMusic { get; set; }
+
+    /// <summary>开启后将作品基础文件名上限从 170 放宽到 220 个字符。</summary>
+    public bool EnableLongFileNames { get; set; }
 
     /// <summary>作品媒体下载速度上限，单位 MB/s；0 表示不限速。</summary>
     public decimal DownloadSpeedLimitMBps { get; set; }

--- a/src/HelloCrab.Core/Services/Settings/LongFileNameState.cs
+++ b/src/HelloCrab.Core/Services/Settings/LongFileNameState.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace HelloCrab.Core.Services.Settings;
 
 public static class LongFileNameState

--- a/src/HelloCrab.Core/Services/Settings/LongFileNameState.cs
+++ b/src/HelloCrab.Core/Services/Settings/LongFileNameState.cs
@@ -1,0 +1,19 @@
+namespace HelloCrab.Core.Services.Settings;
+
+public static class LongFileNameState
+{
+    public const int StandardWorkBaseNameMaxLength = 170;
+    public const int ExtendedWorkBaseNameMaxLength = 220;
+
+    private static int _enabled;
+
+    public static bool Enabled => Volatile.Read(ref _enabled) != 0;
+
+    public static int CurrentWorkBaseNameMaxLength
+        => Enabled
+            ? ExtendedWorkBaseNameMaxLength
+            : StandardWorkBaseNameMaxLength;
+
+    public static void Set(bool enabled)
+        => Volatile.Write(ref _enabled, enabled ? 1 : 0);
+}

--- a/src/HelloCrab.Core/Services/Settings/SettingsService.cs
+++ b/src/HelloCrab.Core/Services/Settings/SettingsService.cs
@@ -40,6 +40,7 @@ public sealed class SettingsService
                 var defaults = new AppSettings();
                 EnsureRemoteToken(defaults);
                 RemoteApiPortState.Set(defaults.RemoteApiPort);
+                LongFileNameState.Set(defaults.EnableLongFileNames);
                 return defaults;
             }
 
@@ -55,10 +56,11 @@ public sealed class SettingsService
             }
 
             // v4 增加 PushPlusToken；v6 清理已经下线的平台配置字段；v7 增加微博平台；
-            // v8 增加人像检测开关；v9 增加视频音轨检测开关；v10 增加 JSON 多语言；v11 增加下载速度限制；v12 增加人像检测置信度。
+            // v8 增加人像检测开关；v9 增加视频音轨检测开关；v10 增加 JSON 多语言；
+            // v11 增加下载速度限制；v12 增加人像检测置信度；v13 增加长文件名开关。
             // 未知旧字段会在下次保存时自然移除。
-            if (settings.Version < 12)
-                settings.Version = 12;
+            if (settings.Version < 13)
+                settings.Version = 13;
             if (string.IsNullOrWhiteSpace(settings.LanguageCode))
                 settings.LanguageCode = "zh-CN";
 
@@ -76,6 +78,7 @@ public sealed class SettingsService
                 10000);
             settings.RemoteApiPort = RemoteApiPortState.Normalize(settings.RemoteApiPort);
             RemoteApiPortState.Set(settings.RemoteApiPort);
+            LongFileNameState.Set(settings.EnableLongFileNames);
             EnsureRemoteToken(settings);
 
             return settings;
@@ -86,6 +89,7 @@ public sealed class SettingsService
             var defaults = new AppSettings();
             EnsureRemoteToken(defaults);
             RemoteApiPortState.Set(defaults.RemoteApiPort);
+            LongFileNameState.Set(defaults.EnableLongFileNames);
             return defaults;
         }
     }
@@ -103,9 +107,10 @@ public sealed class SettingsService
             if (!string.IsNullOrWhiteSpace(directory))
                 Directory.CreateDirectory(directory);
 
-            // MainWindowViewModel 的其他设置可能在端口修改后继续触发延迟保存。
-            // 每次序列化前都使用当前进程端口，避免旧快照把新端口覆盖回去。
+            // MainWindowViewModel 的其他设置可能在端口或文件名策略修改后继续触发延迟保存。
+            // 每次序列化前都使用当前进程状态，避免旧快照把新值覆盖回去。
             settings.RemoteApiPort = RemoteApiPortState.Current;
+            settings.EnableLongFileNames = LongFileNameState.Enabled;
 
             var json = JsonSerializer.Serialize(settings, JsonOptions);
             var tempPath = SettingsPath + ".tmp";

--- a/src/HelloCrab.Core/Utilities/FileNameHelper.cs
+++ b/src/HelloCrab.Core/Utilities/FileNameHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Text;
+using HelloCrab.Core.Services.Settings;
 
 namespace HelloCrab.Core.Utilities;
 
@@ -71,8 +72,11 @@ public static class FileNameHelper
         string? description,
         string? workId,
         bool includeWorkId,
-        int maxLength = 170)
+        int? maxLength = null)
     {
+        var effectiveMaxLength = Math.Max(
+            1,
+            maxLength ?? LongFileNameState.CurrentWorkBaseNameMaxLength);
         var datePrefix = localPublishedAt.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture);
         var safeWorkId = includeWorkId && !string.IsNullOrWhiteSpace(workId)
             ? Sanitize(workId, 64)
@@ -81,11 +85,11 @@ public static class FileNameHelper
 
         // 格式：yyyy-MM-dd HH-mm-ss标题[_作品ID]
         // 没有文案时只使用发布时间；图集序号由下载层最后追加。
-        var titleLength = Math.Max(1, maxLength - datePrefix.Length - idSuffix.Length);
+        var titleLength = Math.Max(1, effectiveMaxLength - datePrefix.Length - idSuffix.Length);
         var safeTitle = string.IsNullOrWhiteSpace(description)
             ? string.Empty
             : Sanitize(description, titleLength);
-        return Sanitize(datePrefix + safeTitle + idSuffix, maxLength);
+        return Sanitize(datePrefix + safeTitle + idSuffix, effectiveMaxLength);
     }
 
     public static string ShortenId(string id)

--- a/src/HelloCrab.Core/ViewModels/MainWindowViewModel.LongFileNames.cs
+++ b/src/HelloCrab.Core/ViewModels/MainWindowViewModel.LongFileNames.cs
@@ -1,0 +1,76 @@
+using HelloCrab.Core.Services.Settings;
+
+namespace HelloCrab.Core.ViewModels;
+
+public sealed partial class MainWindowViewModel
+{
+    private bool _longFileNameLocalizationSubscribed;
+
+    public bool EnableLongFileNames
+    {
+        get => LongFileNameState.Enabled;
+        set
+        {
+            if (LongFileNameState.Enabled == value)
+                return;
+
+            LongFileNameState.Set(value);
+            OnPropertyChanged(nameof(EnableLongFileNames));
+            QueueSettingsSave();
+        }
+    }
+
+    public string LongFileNameSettingText
+    {
+        get
+        {
+            EnsureLongFileNameLocalizationSubscription();
+            return _localization.Get(
+                "Download.LongFileNames",
+                LongFileNameLocalizedText(
+                    "解除长路径限制",
+                    "Allow longer file names",
+                    "長いファイル名を許可"));
+        }
+    }
+
+    public string LongFileNameSettingDescriptionText
+    {
+        get
+        {
+            EnsureLongFileNameLocalizationSubscription();
+            return _localization.Get(
+                "Download.LongFileNamesDescription",
+                LongFileNameLocalizedText(
+                    "开启后作品标题文件名最长由 170 提高到 220 个字符；仍受操作系统和文件系统限制。",
+                    "When enabled, work title file names can grow from 170 to 220 characters. Operating-system and file-system limits still apply.",
+                    "有効にすると、作品タイトルのファイル名上限を 170 文字から 220 文字へ拡張します。OS とファイルシステムの制限は引き続き適用されます。"));
+        }
+    }
+
+    private void EnsureLongFileNameLocalizationSubscription()
+    {
+        if (_longFileNameLocalizationSubscribed)
+            return;
+
+        _longFileNameLocalizationSubscribed = true;
+        _localization.LanguageChanged += (_, _) => Ui(() =>
+        {
+            OnPropertyChanged(nameof(LongFileNameSettingText));
+            OnPropertyChanged(nameof(LongFileNameSettingDescriptionText));
+        });
+    }
+
+    private string LongFileNameLocalizedText(
+        string chinese,
+        string english,
+        string japanese)
+    {
+        var code = _localization.CurrentLanguageCode;
+        if (code.StartsWith("en", StringComparison.OrdinalIgnoreCase))
+            return english;
+        if (code.StartsWith("ja", StringComparison.OrdinalIgnoreCase))
+            return japanese;
+        return chinese;
+    }
+}

--- a/src/HelloCrab.Core/Views/MainWindow.axaml
+++ b/src/HelloCrab.Core/Views/MainWindow.axaml
@@ -395,6 +395,20 @@
                            Foreground="#F59E0B"
                            Text="{DynamicResource Lang.Download.PageDelay}"
                            TextWrapping="Wrap" />
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                  <StackPanel Spacing="2" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding LongFileNameSettingText}"
+                               FontWeight="Medium" />
+                    <TextBlock Classes="caption"
+                               Text="{Binding LongFileNameSettingDescriptionText}"
+                               TextWrapping="Wrap" />
+                  </StackPanel>
+                  <ToggleSwitch Grid.Column="1"
+                                IsChecked="{Binding EnableLongFileNames, Mode=TwoWay}"
+                                OnContent="{DynamicResource Lang.Common.Enabled}"
+                                OffContent="{DynamicResource Lang.Common.Disabled}"
+                                VerticalAlignment="Center" />
+                </Grid>
                 <Grid ColumnDefinitions="*,126,Auto" ColumnSpacing="8">
                   <StackPanel Spacing="2" VerticalAlignment="Center">
                     <TextBlock Text="{DynamicResource Lang.Download.SpeedLimit}"


### PR DESCRIPTION
## Changes

- add a directly declared XAML toggle above the download speed limit setting
- keep the default work base filename limit at 170 characters
- raise it to 220 characters when the toggle is enabled
- persist the preference in settings.json (settings version 13)
- apply the same filename policy to normal, batch, scheduled, and YouTube downloads through FileNameHelper
- provide Chinese, English, and Japanese fallback text even when existing external language files do not contain the new keys

This is an application filename-length policy. It does not modify Windows registry or system long-path policy.

No workflow file is added or modified.