### PR TITLE
Localize runtime component statuses

### DIFF
--- a/src/HelloCrab.Core/ViewModels/MainWindowViewModel.RuntimeStatusLocalization.cs
+++ b/src/HelloCrab.Core/ViewModels/MainWindowViewModel.RuntimeStatusLocalization.cs
@@ -1,0 +1,202 @@
+using System.ComponentModel;
+
+namespace HelloCrab.Core.ViewModels;
+
+public enum RemoteApiStatusKind
+{
+    NotStarted,
+    Starting,
+    RunningPort,
+    RunningAddresses,
+    Stopping,
+    Stopped,
+    StartFailedPortInUse,
+    StartFailed
+}
+
+public sealed partial class MainWindowViewModel
+{
+    private bool _runtimeStatusLocalizationInitialized;
+    private bool _runtimeStatusLocalizationUpdating;
+    private RemoteApiStatusKind _remoteApiStatusKind = RemoteApiStatusKind.NotStarted;
+    private string? _remoteApiStatusDetail;
+
+    /// <summary>
+    /// 桌面宿主在 ViewModel 创建后调用一次。运行状态不依赖磁盘语言包是否已经更新；
+    /// 旧语言包缺少新键时，仍按当前中、英、日语言使用正确的回退文案。
+    /// </summary>
+    public void InitializeRuntimeStatusLocalization()
+    {
+        if (_runtimeStatusLocalizationInitialized)
+            return;
+
+        _runtimeStatusLocalizationInitialized = true;
+        PropertyChanged += RuntimeStatusLocalization_PropertyChanged;
+        _localization.LanguageChanged += RuntimeStatusLocalization_LanguageChanged;
+
+        RefreshLocalizedPersonDetectionModelStatus();
+        RefreshLocalizedRemoteApiStatus();
+    }
+
+    public void SetRemoteApiStatus(RemoteApiStatusKind kind, string? detail = null)
+    {
+        Ui(() =>
+        {
+            _remoteApiStatusKind = kind;
+            _remoteApiStatusDetail = detail;
+            RefreshLocalizedRemoteApiStatus();
+        });
+    }
+
+    private void RuntimeStatusLocalization_LanguageChanged(object? sender, EventArgs e)
+        => Ui(() =>
+        {
+            RefreshLocalizedPersonDetectionModelStatus();
+            RefreshLocalizedRemoteApiStatus();
+        });
+
+    private void RuntimeStatusLocalization_PropertyChanged(
+        object? sender,
+        PropertyChangedEventArgs e)
+    {
+        if (_runtimeStatusLocalizationUpdating)
+            return;
+
+        // 旧采集逻辑仍会在模型状态变化时生成一次中文状态。这里立即根据当前语言
+        // 重新生成，保证模型下载、开关变化和运行时重新检测后也不会回到中文。
+        if (e.PropertyName == nameof(PersonDetectionModelStatusText))
+            RefreshLocalizedPersonDetectionModelStatus();
+    }
+
+    private void RefreshLocalizedPersonDetectionModelStatus()
+    {
+        var modelInfo = _personImageDetector.GetModelInfo();
+        var text = modelInfo.IsFound
+            ? FormatRuntimeStatusText(
+                "Runtime.PersonDetection.ModelFound",
+                "已发现 YOLO 模型：{0}\n位置：{1}",
+                "YOLO model found: {0}\nLocation: {1}",
+                "YOLO モデルを検出しました：{0}\n場所：{1}",
+                modelInfo.ModelName,
+                modelInfo.ModelPath)
+            : RuntimeStatusText(
+                "Runtime.PersonDetection.ModelMissing",
+                "未发现 YOLO 模型。请将 person-detection.onnx、yolo11.onnx，或 yolo11 后带任意一个字母的 ONNX 模型放入程序根目录的 Models 文件夹。",
+                "YOLO model not found. Put person-detection.onnx, yolo11.onnx, or a yolo11 ONNX model with any one-letter suffix in the Models folder beside the application.",
+                "YOLO モデルが見つかりません。person-detection.onnx、yolo11.onnx、または yolo11 の後に任意の英字 1 文字が付く ONNX モデルを、アプリと同じ場所の Models フォルダーに配置してください。");
+
+        SetRuntimeStatusText(() => PersonDetectionModelStatusText = text);
+    }
+
+    private void RefreshLocalizedRemoteApiStatus()
+    {
+        var detail = _remoteApiStatusDetail ?? string.Empty;
+        var text = _remoteApiStatusKind switch
+        {
+            RemoteApiStatusKind.Starting => RuntimeStatusText(
+                "Runtime.Remote.Starting",
+                "正在启动远程服务器…",
+                "Starting remote server…",
+                "リモートサーバーを起動しています…"),
+            RemoteApiStatusKind.RunningPort => FormatRuntimeStatusText(
+                "Runtime.Remote.RunningPort",
+                "运行中 · 端口 {0}",
+                "Running · Port {0}",
+                "稼働中 · ポート {0}",
+                detail),
+            RemoteApiStatusKind.RunningAddresses => FormatRuntimeStatusText(
+                "Runtime.Remote.RunningAddresses",
+                "运行中 · {0}",
+                "Running · {0}",
+                "稼働中 · {0}",
+                detail),
+            RemoteApiStatusKind.Stopping => RuntimeStatusText(
+                "Runtime.Remote.Stopping",
+                "正在关闭远程服务器…",
+                "Stopping remote server…",
+                "リモートサーバーを停止しています…"),
+            RemoteApiStatusKind.Stopped => RuntimeStatusText(
+                "Runtime.Remote.Stopped",
+                "已关闭 · 手机和网页端无法连接",
+                "Stopped · Mobile and web clients cannot connect",
+                "停止済み · モバイル端末と Web クライアントは接続できません"),
+            RemoteApiStatusKind.StartFailedPortInUse => FormatRuntimeStatusText(
+                "Runtime.Remote.StartFailedPortInUse",
+                "启动失败：端口 {0} 已被占用，请修改远程端口后保存。",
+                "Start failed: port {0} is already in use. Change the remote port and save it.",
+                "起動に失敗しました：ポート {0} は既に使用されています。リモートポートを変更して保存してください。",
+                detail),
+            RemoteApiStatusKind.StartFailed => FormatRuntimeStatusText(
+                "Runtime.Remote.StartFailed",
+                "启动失败：{0}",
+                "Start failed: {0}",
+                "起動に失敗しました：{0}",
+                detail),
+            _ => RuntimeStatusText(
+                "Runtime.Remote.NotStarted",
+                "远程服务器未启动",
+                "Remote server not started",
+                "リモートサーバーは起動していません")
+        };
+
+        SetRuntimeStatusText(() => RemoteApiStatusText = text);
+    }
+
+    private void SetRuntimeStatusText(Action setter)
+    {
+        if (_runtimeStatusLocalizationUpdating)
+            return;
+
+        _runtimeStatusLocalizationUpdating = true;
+        try
+        {
+            setter();
+        }
+        finally
+        {
+            _runtimeStatusLocalizationUpdating = false;
+        }
+    }
+
+    private string RuntimeStatusText(
+        string key,
+        string chinese,
+        string english,
+        string japanese)
+    {
+        var fallback = CurrentRuntimeLanguageFallback(chinese, english, japanese);
+        return _localization.Get(key, fallback);
+    }
+
+    private string FormatRuntimeStatusText(
+        string key,
+        string chinese,
+        string english,
+        string japanese,
+        params object?[] arguments)
+    {
+        var fallback = CurrentRuntimeLanguageFallback(chinese, english, japanese);
+        var template = _localization.Get(key, fallback);
+        try
+        {
+            return string.Format(template, arguments);
+        }
+        catch (FormatException)
+        {
+            return string.Format(fallback, arguments);
+        }
+    }
+
+    private string CurrentRuntimeLanguageFallback(
+        string chinese,
+        string english,
+        string japanese)
+    {
+        var code = _localization.CurrentLanguageCode;
+        if (code.StartsWith("en", StringComparison.OrdinalIgnoreCase))
+            return english;
+        if (code.StartsWith("ja", StringComparison.OrdinalIgnoreCase))
+            return japanese;
+        return chinese;
+    }
+}

--- a/src/HelloCrab.Core/ViewModels/MainWindowViewModel.RuntimeStatusLocalization.cs
+++ b/src/HelloCrab.Core/ViewModels/MainWindowViewModel.RuntimeStatusLocalization.cs
@@ -18,6 +18,7 @@ public sealed partial class MainWindowViewModel
 {
     private bool _runtimeStatusLocalizationInitialized;
     private bool _runtimeStatusLocalizationUpdating;
+    private bool _remoteApiStatusIsStructured = true;
     private RemoteApiStatusKind _remoteApiStatusKind = RemoteApiStatusKind.NotStarted;
     private string? _remoteApiStatusDetail;
 
@@ -42,6 +43,7 @@ public sealed partial class MainWindowViewModel
     {
         Ui(() =>
         {
+            _remoteApiStatusIsStructured = true;
             _remoteApiStatusKind = kind;
             _remoteApiStatusDetail = detail;
             RefreshLocalizedRemoteApiStatus();
@@ -52,7 +54,8 @@ public sealed partial class MainWindowViewModel
         => Ui(() =>
         {
             RefreshLocalizedPersonDetectionModelStatus();
-            RefreshLocalizedRemoteApiStatus();
+            if (_remoteApiStatusIsStructured)
+                RefreshLocalizedRemoteApiStatus();
         });
 
     private void RuntimeStatusLocalization_PropertyChanged(
@@ -65,7 +68,15 @@ public sealed partial class MainWindowViewModel
         // 旧采集逻辑仍会在模型状态变化时生成一次中文状态。这里立即根据当前语言
         // 重新生成，保证模型下载、开关变化和运行时重新检测后也不会回到中文。
         if (e.PropertyName == nameof(PersonDetectionModelStatusText))
+        {
             RefreshLocalizedPersonDetectionModelStatus();
+        }
+        else if (e.PropertyName == nameof(RemoteApiStatusText))
+        {
+            // 远程端口编辑器已有自己的三语言即时提示。它通过旧字符串接口写入时，
+            // 不应被之前保存的服务器生命周期状态覆盖。
+            _remoteApiStatusIsStructured = false;
+        }
     }
 
     private void RefreshLocalizedPersonDetectionModelStatus()
@@ -90,6 +101,9 @@ public sealed partial class MainWindowViewModel
 
     private void RefreshLocalizedRemoteApiStatus()
     {
+        if (!_remoteApiStatusIsStructured)
+            return;
+
         var detail = _remoteApiStatusDetail ?? string.Empty;
         var text = _remoteApiStatusKind switch
         {

--- a/src/HelloCrab.Desktop/App.axaml.cs
+++ b/src/HelloCrab.Desktop/App.axaml.cs
@@ -79,6 +79,7 @@ public partial class App : Application
                 platformShell,
                 ffmpegInstaller,
                 personImageDetector);
+            viewModel.InitializeRuntimeStatusLocalization();
 
             _viewModel = viewModel;
             _remoteApiHost = new RemoteApiHostService(viewModel);
@@ -119,7 +120,7 @@ public partial class App : Application
         catch (Exception ex)
         {
             _viewModel?.AddRemoteLog($"切换远程控制服务器失败：{ex.Message}");
-            _viewModel?.SetRemoteApiStatus($"启动失败：{ex.Message}");
+            _viewModel?.SetRemoteApiStatus(RemoteApiStatusKind.StartFailed, ex.Message);
         }
         finally
         {
@@ -146,7 +147,7 @@ public partial class App : Application
         catch (Exception ex)
         {
             _viewModel?.AddRemoteLog($"切换远程端口失败：{ex.Message}");
-            _viewModel?.SetRemoteApiStatus($"启动失败：{ex.Message}");
+            _viewModel?.SetRemoteApiStatus(RemoteApiStatusKind.StartFailed, ex.Message);
         }
         finally
         {

--- a/src/HelloCrab.Desktop/Remote/RemoteApiHostService.cs
+++ b/src/HelloCrab.Desktop/Remote/RemoteApiHostService.cs
@@ -53,14 +53,16 @@ public sealed class RemoteApiHostService : IAsyncDisposable
     {
         if (_application is not null)
         {
-            _viewModel.SetRemoteApiStatus($"运行中 · 端口 {_viewModel.EffectiveRemoteApiPort}");
+            _viewModel.SetRemoteApiStatus(
+                RemoteApiStatusKind.RunningPort,
+                _viewModel.EffectiveRemoteApiPort.ToString());
             return;
         }
 
         WebApplication? app = null;
         try
         {
-            _viewModel.SetRemoteApiStatus("正在启动远程服务器…");
+            _viewModel.SetRemoteApiStatus(RemoteApiStatusKind.Starting);
 
             var builder = WebApplication.CreateSlimBuilder();
             builder.WebHost.UseUrls($"http://0.0.0.0:{_viewModel.EffectiveRemoteApiPort}");
@@ -165,7 +167,9 @@ public sealed class RemoteApiHostService : IAsyncDisposable
                 ? $"http://127.0.0.1:{_viewModel.EffectiveRemoteApiPort}"
                 : string.Join("、", addresses);
 
-            _viewModel.SetRemoteApiStatus($"运行中 · {addressText}");
+            _viewModel.SetRemoteApiStatus(
+                RemoteApiStatusKind.RunningAddresses,
+                addressText);
             _viewModel.AddRemoteLog($"远程控制服务已启动：{addressText}");
             _viewModel.AddRemoteLog($"远程访问令牌：{_viewModel.RemoteApiToken}");
         }
@@ -178,12 +182,16 @@ public sealed class RemoteApiHostService : IAsyncDisposable
             {
                 var message =
                     $"启动失败：端口 {_viewModel.EffectiveRemoteApiPort} 已被占用，请修改远程端口后保存。";
-                _viewModel.SetRemoteApiStatus(message);
+                _viewModel.SetRemoteApiStatus(
+                    RemoteApiStatusKind.StartFailedPortInUse,
+                    _viewModel.EffectiveRemoteApiPort.ToString());
                 _viewModel.AddRemoteLog($"远程控制服务{message}");
             }
             else
             {
-                _viewModel.SetRemoteApiStatus($"启动失败：{ex.Message}");
+                _viewModel.SetRemoteApiStatus(
+                    RemoteApiStatusKind.StartFailed,
+                    ex.Message);
                 _viewModel.AddRemoteLog($"远程控制服务启动失败：{ex.Message}");
             }
         }
@@ -194,11 +202,11 @@ public sealed class RemoteApiHostService : IAsyncDisposable
         var application = Interlocked.Exchange(ref _application, null);
         if (application is null)
         {
-            _viewModel.SetRemoteApiStatus("已关闭 · 手机和网页端无法连接");
+            _viewModel.SetRemoteApiStatus(RemoteApiStatusKind.Stopped);
             return;
         }
 
-        _viewModel.SetRemoteApiStatus("正在关闭远程服务器…");
+        _viewModel.SetRemoteApiStatus(RemoteApiStatusKind.Stopping);
         try
         {
             await application.StopAsync(TimeSpan.FromSeconds(3));
@@ -208,7 +216,7 @@ public sealed class RemoteApiHostService : IAsyncDisposable
             await application.DisposeAsync();
         }
 
-        _viewModel.SetRemoteApiStatus("已关闭 · 手机和网页端无法连接");
+        _viewModel.SetRemoteApiStatus(RemoteApiStatusKind.Stopped);
         _viewModel.AddRemoteLog("远程控制服务已关闭，端口已停止监听。");
     }
 


### PR DESCRIPTION
## Changes

- localize the YOLO model found/missing status in Chinese, English, and Japanese
- localize remote server lifecycle statuses including starting, running, stopping, stopped, port-in-use, and generic startup failure
- refresh both statuses immediately when the interface language changes or language packs are reloaded
- preserve the existing localized transient messages from the remote-port editor
- initialize runtime-status localization before the main window DataContext is displayed
- provide language-specific fallbacks when existing external language files do not contain the new keys

No workflow file is added or modified.